### PR TITLE
Fix issues with the provided database setup

### DIFF
--- a/baseBdd.sql
+++ b/baseBdd.sql
@@ -402,6 +402,7 @@ CREATE TABLE `texts` (
   `is_negation_specification_test` tinyint(4) DEFAULT 0,
   `is_active` tinyint(4) DEFAULT 1,
   `length` int(11) DEFAULT 0,
+  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=441 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -728,7 +729,7 @@ CREATE TABLE `users` (
   `trust_index` tinyint(1) DEFAULT 50,
   `notifications_enabled` tinyint(1) DEFAULT 1,
   `gender` enum('homme','femme') NOT NULL DEFAULT 'homme',
-  `created_at` varchar(45) DEFAULT current_timestamp(),
+  `created_at` varchar(45) DEFAULT 'CURRENT_TIMESTAMP',
   `color_skin` enum('clear','medium','dark') DEFAULT 'medium',
   `tutorial_progress` tinyint(4) DEFAULT 0,
   `moderator` tinyint(4) NOT NULL DEFAULT 0,

--- a/controllers/textController.js
+++ b/controllers/textController.js
@@ -375,7 +375,7 @@ const createText = async (req, res) => {
    
           res.status(201).json(text);
         } catch (innerError) {
-          console.error(`Database or data error: ${innerError}`);
+          console.error(`Database or data error when creating a text: ${innerError}`);
           res.status(500).json({ error: innerError.message });
         }
       }


### PR DESCRIPTION
`created_at` fields in the `baseBdd.sql` script caused issues that prevented from "importing" the tables altogether, or also importing texts on HostoMytho. This PR fixes this.

One thing I don't understand is why some `created_at` fields are using `VARCHAR(45)` as type instead of `DATETIME` like others. I don't really plan on investigating this, but I suppose we should be cautious when deploying on the production environment.